### PR TITLE
feat: Adding requested buttons to the primary nav.

### DIFF
--- a/_includes/docs-navbar.html
+++ b/_includes/docs-navbar.html
@@ -85,6 +85,6 @@
         {% endcomment %}
       </ul>
     </div>
-    <a class="btn btn-primary order-2 order-md-2" href="https://codefresh.io/docs/" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open CF Classic Docs');" style="background: #11b5a4; border-color: #11b5a4; margin-top: 11px;" >View Classic Docs</a>
+    <a class="btn btn-primary order-2 order-md-2" href="https://codefresh.io/docs/" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open CF Classic Docs');" style="background: #11b5a4; border-color: #11b5a4;" >View Classic Docs</a>
   </div>
 </header>

--- a/_includes/docs-navbar.html
+++ b/_includes/docs-navbar.html
@@ -1,6 +1,6 @@
 <header class="bd-navbar py-2 py-md-0">
   <div class="container-fluid navbar navbar-dark navbar-expand flex-column flex-md-row py-0">
-    <a class="navbar-brand mr-0 mr-md-2" href="{{ site.baseurl }}/" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Home');" aria-label="Codefresh">
+    <a class="navbar-brand mx-0 mx-md-2" href="{{ site.baseurl }}/" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Home');" aria-label="Codefresh">
       {%- include icons/codefresh-icon.svg width="50" height="auto" class="align-middle" -%}
       <span class="badge cf-badge cf-badge-doc align-middle ml-1">Docs</span>
     </a>
@@ -17,73 +17,74 @@
     </form>
     {% endif %}
 
-    <div class="navbar-nav-scroll order-1 order-md-1 mr-md-auto">
-    <ul class="navbar-nav flex-row ml-md-auto">
+    <div class="navbar-nav-scroll order-1 order-md-1 mx-md-auto">
+      <ul class="navbar-nav flex-row mx-md-auto">
 
-      <li class="nav-item">
-        <a class="nav-link" href="{{ site.link_main }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Product');">Product</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link {% if page.layout == "docs" %}active{% endif %}" href="{{ site.baseurl }}/docs/getting-started/accessing-cap/" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Docs');">Docs</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="{{ site.link_plugins }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open Plugins');" target="_blank" rel="noopener">Plugins</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="{{ site.link_community }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open Community');" target="_blank" rel="noopener">Community</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="{{ site.link_cli }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open CLI Docs');" target="_blank" rel="noopener">CLI</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="{{ site.link_api }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open API Swagger');" target="_blank" rel="noopener">API</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="{{ site.baseurl }}/docs/whats-new/whats-new/" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open Changelog');" >Changelog</a>
-      </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ site.link_main }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Product');">Product</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link {% if page.layout == "docs" %}active{% endif %}" href="{{ site.baseurl }}/docs/getting-started/accessing-cap/" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Docs');">Docs</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ site.link_plugins }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open Plugins');" target="_blank" rel="noopener">Plugins</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ site.link_community }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open Community');" target="_blank" rel="noopener">Community</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ site.link_cli }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open CLI Docs');" target="_blank" rel="noopener">CLI</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ site.link_api }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open API Swagger');" target="_blank" rel="noopener">API</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ site.baseurl }}/docs/whats-new/whats-new/" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open Changelog');" >Changelog</a>
+        </li>
 
-      {% comment %}
-      <li class="nav-item">
-        <a class="nav-link" href="{{ site.features }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Features');" target="_blank" rel="noopener">Features</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="{{ site.enterprise }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Enterprise');" target="_blank" rel="noopener">Enterprise</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="{{ site.pricing }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Pricing');" target="_blank" rel="noopener">Pricing</a>
-      </li>
-      <li class="nav-item bulb bulb-red" data-bulb-text="LIVE">
-        <a class="nav-link" href="{{ site.schedule_demo }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Schedule Demo');" target="_blank" rel="noopener">Schedule demo</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="{{ site.codefresh_login }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Login');" target="_blank" rel="noopener">Login</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="{{ site.codefresh_signup }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'SignUp');" target="_blank" rel="noopener">SignUp</a>
-      </li>
-      <!--
-      <li class="nav-item dropdown">
-        <a class="nav-item nav-link dropdown-toggle mr-md-2" href="#" id="bd-versions" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          v1.2
-        </a>
-        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="bd-versions">
-          <a class="dropdown-item active" href="{{ site.baseurl }}/docs/">Latest</a>
-        </div>
-      </li>
+        {% comment %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ site.features }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Features');" target="_blank" rel="noopener">Features</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ site.enterprise }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Enterprise');" target="_blank" rel="noopener">Enterprise</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ site.pricing }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Pricing');" target="_blank" rel="noopener">Pricing</a>
+        </li>
+        <li class="nav-item bulb bulb-red" data-bulb-text="LIVE">
+          <a class="nav-link" href="{{ site.schedule_demo }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Schedule Demo');" target="_blank" rel="noopener">Schedule demo</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ site.codefresh_login }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Login');" target="_blank" rel="noopener">Login</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ site.codefresh_signup }}" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'SignUp');" target="_blank" rel="noopener">SignUp</a>
+        </li>
+        <!--
+        <li class="nav-item dropdown">
+          <a class="nav-item nav-link dropdown-toggle mr-md-2" href="#" id="bd-versions" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            v1.2
+          </a>
+          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="bd-versions">
+            <a class="dropdown-item active" href="{{ site.baseurl }}/docs/">Latest</a>
+          </div>
+        </li>
 
-      <li class="nav-item">
-        <a class="nav-link p-2" href="{{ site.repo }}" target="_blank" rel="noopener" aria-label="GitHub">
-          {%- include icons/github.svg class="navbar-nav-svg" -%}
-        </a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link p-2" href="https://twitter.com/{{ site.twitter }}" target="_blank" rel="noopener" aria-label="Twitter">
-          {%- include icons/twitter.svg class="navbar-nav-svg" -%}
-        </a>
-      </li>
-      -->
-      {% endcomment %}
-    </ul>
+        <li class="nav-item">
+          <a class="nav-link p-2" href="{{ site.repo }}" target="_blank" rel="noopener" aria-label="GitHub">
+            {%- include icons/github.svg class="navbar-nav-svg" -%}
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link p-2" href="https://twitter.com/{{ site.twitter }}" target="_blank" rel="noopener" aria-label="Twitter">
+            {%- include icons/twitter.svg class="navbar-nav-svg" -%}
+          </a>
+        </li>
+        -->
+        {% endcomment %}
+      </ul>
     </div>
+    <a class="btn btn-primary order-2 order-md-2" href="https://codefresh.io/docs/" onclick="ga('send', 'event', 'Navbar', 'Docs links', 'Open CF Classic Docs');" style="background: #11b5a4; border-color: #11b5a4; margin-top: 11px;" >View Classic Docs</a>
   </div>
 </header>


### PR DESCRIPTION
Signed-off-by: Brandon Lyon <brandonlyon@Brandons-MacBook-Pro-2.local>

Per request from Noga, adding a button to the primary navigation that links to the other version of the docs site.

Note that the version of SASS used in the docs site is 4.7, which appears to require node version 8 (the current version is 17). I don't think I can compile CSS because it doesn't support recent versions of Mac OS. I tried using the docker method but that doesn't appear to compile SASS/CSS.

Long term we'll want to update the package versions. For now, I can try to style the requested v1/v2 navigation buttons using inline `<style>` tags.