### PR TITLE
Add Google tag manager

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,11 @@
     {% include header.html %}
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WV3QT3W"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
     <a id="skippy" class="sr-only sr-only-focusable" href="#content">
       <div class="container">
         <span class="skiplink-text">Skip to main content</span>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -8,6 +8,14 @@ layout: compress
     {% include header.html %}
   </head>
   <body data-spy="scroll" data-target=".bd-toc" data-offset="100">
+
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WV3QT3W"
+      height="0" width="0" style="display:none;visibility:hidden"></iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
     <a id="skippy" class="sr-only sr-only-focusable" href="#content">
       <div class="container">
         <span class="skiplink-text">Skip to main content</span>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,6 +4,14 @@
     {% include header.html %}
   </head>
   <body>
+
+  <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WV3QT3W"
+      height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
     <a id="skippy" class="sr-only sr-only-focusable" href="#content">
       <div class="container">
         <span class="skiplink-text">Skip to main content</span>

--- a/_layouts/no-header-footer.html
+++ b/_layouts/no-header-footer.html
@@ -4,6 +4,15 @@
     {% include header.html %}
   </head>
   <body>
+
+  <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WV3QT3W"
+      height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
+
     <a id="skippy" class="sr-only sr-only-focusable" href="#content">
       <div class="container">
         <span class="skiplink-text">Skip to main content</span>

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -31,6 +31,13 @@
     </style>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WV3QT3W"
+      height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
     <h1>Redirecting&hellip;</h1>
     <a href="{{ page.redirect.to }}">Click here if you are not redirected</a>
     <script>window.location="{{ page.redirect.to }}";</script>


### PR DESCRIPTION
Added GA analytics tracking code to required files in -layout- based on CF classic docs:
default, docs, home, no-header-footer, redirect