### PR TITLE
Bring ingress documentation inline

### DIFF
--- a/_docs/runtime/requirements.md
+++ b/_docs/runtime/requirements.md
@@ -51,6 +51,11 @@ See additional configuration options in the [ingress-nginx documentation for AWS
 See additional configuration options in the [ingress-nginx documentation for AKS](https://docs.microsoft.com/en-us/azure/aks/ingress-internal-ip?tabs=azure-cli#create-an-ingress-controller).
 
 ##### Bare Metal Clusters
+**Using Ingress-Nginx**
+1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/baremetal/deploy.yaml`
+1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+
+Bare metal clusters often have additional considerations. Please review the [ingress-nginx documentation](https://kubernetes.github.io/ingress-nginx/deploy/baremetal/).
 
 ##### Digital Ocean
 **Using Ingress-Nginx**

--- a/_docs/runtime/requirements.md
+++ b/_docs/runtime/requirements.md
@@ -30,36 +30,51 @@ Kubernetes cluster, server version 1.20 or higher, without Argo Project componen
 * Valid SSL certificate  
   The ingress controller must have a valid SSL certificate from an authorized CA (Certificate Authority) for secure runtime installation.  
 
- 
 
-#### Provider-specific NGINX-ingress installation
-To install on an EKS cluster, follow the instructions below. For other providers, see the list of provider-specific installation links.
+#### Provider Specific Instrucitons
 
-##### Install NGINX-ingress on EKS cluster
+Codefresh Software Delivery Platform is tested and supported in major providers. For convenience, provider-specific instructions for providers both supported and untested are included below.
 
-1. Apply:  
-  ```kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.0/deploy/static/provider/aws/deploy.yaml```
+##### AWS
 
-1. Verify you see a valid external IP address:  
-  ```kubectl get svc ingress-nginx-controller -n ingress-nginx``` 
+**Using Ingress-Nginx**
+1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/aws/deploy.yaml`
+1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
 
-##### Provider-specific installation links
+See additional configuration options in the [ingress-nginx documentation for AWS](https://kubernetes.github.io/ingress-nginx/deploy/#aws).
 
-* [MiniKube](https://kubernetes.github.io/ingress-nginx/deploy/#minikube)
-* [MicroK8s](https://kubernetes.github.io/ingress-nginx/deploy/#microk8s)
-* [Docker Desktop](https://kubernetes.github.io/ingress-nginx/deploy/#docker-desktop)
-* [AWS](https://kubernetes.github.io/ingress-nginx/deploy/#aws)
-* [Google Kubernetes Engine (GCP GKE)](https://kubernetes.github.io/ingress-nginx/deploy/#gce-gke) (see also section on Specific requirements for Google Kubernetes Engine (GCP GKE))
-* [Azure](https://kubernetes.github.io/ingress-nginx/deploy/#azure)
-* [Digital Ocean](https://kubernetes.github.io/ingress-nginx/deploy/#digital-ocean)
-* [Scale Away](https://kubernetes.github.io/ingress-nginx/deploy/#scaleway)
-* [Exoscale](https://kubernetes.github.io/ingress-nginx/deploy/#exoscale)
-* [Oracle Cloud Infrastructure](https://kubernetes.github.io/ingress-nginx/deploy/#oracle-cloud-infrastructure)
-* [Bare Metal Clusters](https://kubernetes.github.io/ingress-nginx/deploy/#bare-metal-clusters)
+##### Azure (AKS)
+**Using Ingress-Nginx**
+1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/cloud/deploy.yaml`
+1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
 
+See additional configuration options in the [ingress-nginx documentation for AKS](https://docs.microsoft.com/en-us/azure/aks/ingress-internal-ip?tabs=azure-cli#create-an-ingress-controller).
 
-**Specific requirements for Google Kubernetes Engine (GCP GKE)**  
+##### Bare Metal Clusters
 
+##### Digital Ocean
+**Using Ingress-Nginx**
+1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/do/deploy.yaml`
+1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+
+See additional configuration options in the [ingress-nginx documentation for Digital Ocean](https://kubernetes.github.io/ingress-nginx/deploy/#digital-ocean).
+
+##### Docker Desktop
+**Using Ingress-Nginx**
+1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/cloud/deploy.yaml`
+1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+
+See additional configuration options in the [ingress-nginx documentation for Docker Desktop](https://kubernetes.github.io/ingress-nginx/deploy/#docker-desktop). **Note** By default, Docker Desktop services will provision with localhost as their external address. Triggers in delivery pipelines will not be able to reach this instance unless they originate from the same machine where Docker Desktop is being used.
+
+##### Exoscale
+**Using Ingress-Nginx**
+1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/exoscale/deploy.yaml`
+1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+
+See additional configuration options in the [ingress-nginx documentation for Exoscale](https://github.com/exoscale/exoscale-cloud-controller-manager/blob/master/docs/service-loadbalancer.md).
+
+##### Google (GKE)
+**Adding Firewall Rules**
 GKE by default limits outbound requests from nodes. For the runtime to communicate with the control-plane in CSDP, add a firewall-specific rule.
 
 1. Find your cluster's network:   
@@ -73,6 +88,43 @@ GKE by default limits outbound requests from nodes. For the runtime to communica
     --source-ranges="[CLUSTER_IPV4_CIDR]" \
     --allow=tcp,udp,icmp,esp,ah,sctp
     ```
+
+**Using Ingress-Nginx**
+1. Create a `cluster-admin` role binding ```kubectl create clusterrolebinding cluster-admin-binding \
+  --clusterrole cluster-admin \
+  --user $(gcloud config get-value account)```
+1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/cloud/deploy.yaml`
+1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+
+We recommend reviewing the provider [specific documentation for GKE](https://kubernetes.github.io/ingress-nginx/deploy/#gce-gke).
+
+##### MicroK8s
+1. Install using Microk8s addon system `microk8s enable ingress`
+1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+
+MicroK8s has not been tested with CSDP and may require additional configuration. Ingress addon [documentation can be found here](https://microk8s.io/docs/addon-ingress).
+
+##### MiniKube
+1. Install using MiniKube addon system `minikube addons enable ingress`
+1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+
+MiniKube has not been tested with CSDP and may require additional configuration. Ingress addon [documentation can be found here](https://kubernetes.github.io/ingress-nginx/deploy/#minikube).
+
+##### Oracle Cloud Infrastructure
+**Using Ingress-Nginx**
+1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/cloud/deploy.yaml`
+1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+
+See additional configuration options in the [ingress-nginx documentation for Oracle Cloud](https://kubernetes.github.io/ingress-nginx/deploy/#oracle-cloud-infrastructure).
+
+
+##### Scale Away
+**Using Ingress-Nginx**
+1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/scw/deploy.yaml`
+1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+
+See additional configuration options in the [ingress-nginx documentation for Scaleway](https://kubernetes.github.io/ingress-nginx/deploy/#scaleway).
+
 
 #### Node requirements
 * Memory: 5000 MB

--- a/_docs/runtime/requirements.md
+++ b/_docs/runtime/requirements.md
@@ -31,9 +31,9 @@ Kubernetes cluster, server version 1.20 or higher, without Argo Project componen
   The ingress controller must have a valid SSL certificate from an authorized CA (Certificate Authority) for secure runtime installation.  
 
 
-#### Provider Specific Instructions
+#### Provider-specific configuration
 
-CSDP has been tested and supported in major providers. For your convenience, we have included provider-specific instructions for providers, both supported and untested.
+CSDP has been tested and is supported in major providers. For your convenience, we have included provider-specific configuration instructions, both for supported and untested providers.
 
 > The instructions are valid for Ingress-Nginx.
 

--- a/_docs/runtime/requirements.md
+++ b/_docs/runtime/requirements.md
@@ -31,105 +31,211 @@ Kubernetes cluster, server version 1.20 or higher, without Argo Project componen
   The ingress controller must have a valid SSL certificate from an authorized CA (Certificate Authority) for secure runtime installation.  
 
 
-#### Provider Specific Instrucitons
+#### Provider Specific Instructions
 
-Codefresh Software Delivery Platform is tested and supported in major providers. For convenience, provider-specific instructions for providers both supported and untested are included below.
+CSDP has been tested and supported in major providers. For your convenience, we have included provider-specific instructions for providers, both supported and untested.
 
-##### AWS
+> The instructions are valid for Ingress-Nginx.
 
-**Using Ingress-Nginx**
-1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/aws/deploy.yaml`
-1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+<details>
+<summary><b>AWS</b></summary>
+<ol>
+<li>Apply:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/aws/deploy.yaml</span>
+</li>
+<li>Verify a valid external address exists:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl get svc ingress-nginx-controller -n ingress-nginx</span>
+</li>
+</ol>
+For additional configuration options, see <a target="_blank" href="https://kubernetes.github.io/ingress-nginx/deploy/#aws">ingress-nginx documentation for AWS</a>.
+</details>
+<details>
+<summary><b>Azure (AKS)</b></summary>
+<ol>
+<li>Apply:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/cloud/deploy.yaml</span>
+</li>
+<li>Verify a valid external address exists:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl get svc ingress-nginx-controller -n ingress-nginx</span>
+</li>
+</ol>
+For additional configuration options, see <a target="_blank" href="https://docs.microsoft.com/en-us/azure/aks/ingress-internal-ip?tabs=azure-cli#create-an-ingress-controller">ingress-nginx documentation for AKS</a>.
 
-See additional configuration options in the [ingress-nginx documentation for AWS](https://kubernetes.github.io/ingress-nginx/deploy/#aws).
+</details>
 
-##### Azure (AKS)
-**Using Ingress-Nginx**
-1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/cloud/deploy.yaml`
-1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+<details>
+<summary><b>Bare Metal Clusters</b></summary>
+<ol>
+<li>Apply:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/baremetal/deploy.yaml</span>
+</li>
+<li>Verify a valid external address exists:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl get svc ingress-nginx-controller -n ingress-nginx</span>
+</li>
+</ol>
+Bare-metal clusters often have additional considerations. See <a target="_blank" href="https://kubernetes.github.io/ingress-nginx/deploy/baremetal/">Bare-metal ingress-nginx considerations</a>.
 
-See additional configuration options in the [ingress-nginx documentation for AKS](https://docs.microsoft.com/en-us/azure/aks/ingress-internal-ip?tabs=azure-cli#create-an-ingress-controller).
+</details>
 
-##### Bare Metal Clusters
-**Using Ingress-Nginx**
-1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/baremetal/deploy.yaml`
-1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+<details>
+<summary><b>Digital Ocean</b></summary>
+<ol>
+<li>Apply:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/do/deploy.yaml</span>
+</li>
+<li>Verify a valid external address exists:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl get svc ingress-nginx-controller -n ingress-nginx</span>
+</li>
+</ol>
+For additional configuration options, see <a target="_blank" href="https://kubernetes.github.io/ingress-nginx/deploy/#digital-ocean">ingress-nginx documentation for Digital Ocean</a>.
 
-Bare metal clusters often have additional considerations. Please review the [ingress-nginx documentation](https://kubernetes.github.io/ingress-nginx/deploy/baremetal/).
+</details>
 
-##### Digital Ocean
-**Using Ingress-Nginx**
-1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/do/deploy.yaml`
-1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+<details>
+<summary><b>Docker Desktop</b></summary>
+<ol>
+<li>Apply:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/cloud/deploy.yaml</span>
+</li>
+<li>Verify a valid external address exists:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl get svc ingress-nginx-controller -n ingress-nginx</span>
+</li>
+</ol>
+For additional configuration options, see <a target="_blank" href="https://kubernetes.github.io/ingress-nginx/deploy/#docker-desktop">ingress-nginx documentation for Docker Desktop</a>.<br>
+<b>Note:</b> By default, Docker Desktop services will provision with localhost as their external address. Triggers in delivery pipelines cannot reach this instance unless they originate from the same machine where Docker Desktop is being used.
 
-See additional configuration options in the [ingress-nginx documentation for Digital Ocean](https://kubernetes.github.io/ingress-nginx/deploy/#digital-ocean).
+</details>
 
-##### Docker Desktop
-**Using Ingress-Nginx**
-1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/cloud/deploy.yaml`
-1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+<details>
+<summary><b>Exoscale</b></summary>
+<ol>
+<li>Apply:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/exoscale/deploy.yaml</span>
+</li>
+<li>Verify a valid external address exists:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl get svc ingress-nginx-controller -n ingress-nginx</span>
+</li>
+</ol>
+For additional configuration options, see <a target="_blank" href="https://github.com/exoscale/exoscale-cloud-controller-manager/blob/master/docs/service-loadbalancer.md">ingress-nginx documentation for Exoscale</a>.
 
-See additional configuration options in the [ingress-nginx documentation for Docker Desktop](https://kubernetes.github.io/ingress-nginx/deploy/#docker-desktop). **Note** By default, Docker Desktop services will provision with localhost as their external address. Triggers in delivery pipelines will not be able to reach this instance unless they originate from the same machine where Docker Desktop is being used.
+</details>
 
-##### Exoscale
-**Using Ingress-Nginx**
-1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/exoscale/deploy.yaml`
-1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
 
-See additional configuration options in the [ingress-nginx documentation for Exoscale](https://github.com/exoscale/exoscale-cloud-controller-manager/blob/master/docs/service-loadbalancer.md).
-
-##### Google (GKE)
-**Adding Firewall Rules**
+<details>
+<summary><b>Google (GKE)</b></summary>
+<br>
+<b>Add firewall rules</b>
+<br>
 GKE by default limits outbound requests from nodes. For the runtime to communicate with the control-plane in CSDP, add a firewall-specific rule.
 
-1. Find your cluster's network:   
-  `gcloud container clusters describe [CLUSTER_NAME] --format=get"(network)"`
-1. Get the Cluster IPV4 CIDR:  
-  `gcloud container clusters describe [CLUSTER_NAME] --format=get"(clusterIpv4Cidr)"`  
-1. Replace the `[CLUSTER_NAME]`, `[NETWORK]`, and `[CLUSTER_IPV4_CIDR]`, with the relevant values:  
-   ```
-    gcloud compute firewall-rules create "[CLUSTER_NAME]-to-all-vms-on-network" \
+<ol>
+<li>Find your cluster's network:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">gcloud container clusters describe [CLUSTER_NAME] --format=get"(network)"</span>
+</li>
+<li>Get the Cluster IPV4 CIDR:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">gcloud container clusters describe [CLUSTER_NAME] --format=get"(clusterIpv4Cidr)"</span>
+</li>
+<li>Replace the `[CLUSTER_NAME]`, `[NETWORK]`, and `[CLUSTER_IPV4_CIDR]`, with the relevant values: <br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">gcloud compute firewall-rules create "[CLUSTER_NAME]-to-all-vms-on-network" </span><br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">  
     --network="[NETWORK]" \
+    </span><br>
+   <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">  
     --source-ranges="[CLUSTER_IPV4_CIDR]" \
-    --allow=tcp,udp,icmp,esp,ah,sctp
-    ```
+    </span><br>
+   <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">  
+   --allow=tcp,udp,icmp,esp,ah,sctp
+    </span><br>
+</li> 
+</ol>
+<br>
+<b>Use ingress-nginx</b><br>
+<ol>
+  <li>Create a `cluster-admin` role binding:<br>
+      <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">  
+        kubectl create clusterrolebinding cluster-admin-binding \
+      </span><br>
+      <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">  
+        --clusterrole cluster-admin \
+      </span><br>
+      <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">  
+        --user $(gcloud config get-value account)
+      </span><br>
+  </li>
+  <li>Apply:<br>
+      <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">  
+        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/cloud/deploy.yaml
+      </span>
+  </li>
+  <li>Verify a valid external address exists:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl get svc ingress-nginx-controller -n ingress-nginx</span>
+  </li>
 
-**Using Ingress-Nginx**
-1. Create a `cluster-admin` role binding ```kubectl create clusterrolebinding cluster-admin-binding \
-  --clusterrole cluster-admin \
-  --user $(gcloud config get-value account)```
-1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/cloud/deploy.yaml`
-1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+</ol>
+We recommend reviewing the <a target="_blank" href="https://kubernetes.github.io/ingress-nginx/deploy/#gce-gke">provider-specific documentation for GKE</a>.
 
-We recommend reviewing the provider [specific documentation for GKE](https://kubernetes.github.io/ingress-nginx/deploy/#gce-gke).
-
-##### MicroK8s
-1. Install using Microk8s addon system `microk8s enable ingress`
-1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
-
-MicroK8s has not been tested with CSDP and may require additional configuration. Ingress addon [documentation can be found here](https://microk8s.io/docs/addon-ingress).
-
-##### MiniKube
-1. Install using MiniKube addon system `minikube addons enable ingress`
-1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
-
-MiniKube has not been tested with CSDP and may require additional configuration. Ingress addon [documentation can be found here](https://kubernetes.github.io/ingress-nginx/deploy/#minikube).
-
-##### Oracle Cloud Infrastructure
-**Using Ingress-Nginx**
-1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/cloud/deploy.yaml`
-1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
-
-See additional configuration options in the [ingress-nginx documentation for Oracle Cloud](https://kubernetes.github.io/ingress-nginx/deploy/#oracle-cloud-infrastructure).
+</details>
 
 
-##### Scale Away
-**Using Ingress-Nginx**
-1. Apply `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/scw/deploy.yaml`
-1. Verify a valid external address exists `kubectl get svc ingress-nginx-controller -n ingress-nginx`
+<details>
+<summary><b>MicroK8s</b></summary>
+<ol>
+<li>Install using Microk8s addon system:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">microk8s enable ingress</span>
+</li>
+<li>Verify a valid external address exists:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl get svc ingress-nginx-controller -n ingress-nginx</span>
+</li>
+</ol>
+MicroK8s has not been tested with CSDP, and may require additional configuration. For details, see <a target="_blank" href="https://microk8s.io/docs/addon-ingress">Ingress addon documentation</a>.
 
-See additional configuration options in the [ingress-nginx documentation for Scaleway](https://kubernetes.github.io/ingress-nginx/deploy/#scaleway).
+</details>
 
+
+<details>
+<summary><b>MiniKube</b></summary>
+<ol>
+<li>Install using MiniKube addon system:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">minikube addons enable ingress</span>
+</li>
+<li>Verify a valid external address exists:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl get svc ingress-nginx-controller -n ingress-nginx</span>
+</li>
+</ol>
+MiniKube has not been tested with CSDP, and may require additional configuration. For details, see <a target="_blank" href="https://kubernetes.github.io/ingress-nginx/deploy/#minikube">Ingress addon documentation</a>.
+
+</details>
+
+
+
+<details>
+<summary><b>Oracle Cloud Infrastructure</b></summary>
+<ol>
+<li>Apply:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/cloud/deploy.yaml</span>
+</li>
+<li>Verify a valid external address exists:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl get svc ingress-nginx-controller -n ingress-nginx</span>
+</li>
+</ol>
+For additional configuration options, see <a target="_blank" href="https://kubernetes.github.io/ingress-nginx/deploy/#oracle-cloud-infrastructure">ingress-nginx documentation for Oracle Cloud</a>.
+
+</details>
+
+<details>
+<summary><b>Scaleway</b></summary>
+<ol>
+<li>Apply:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.1.1/deploy/static/provider/scw/deploy.yaml</span>
+</li>
+<li>Verify a valid external address exists:<br>
+    <span style="font-family: var(--font-family-monospace); font-size: 87.5%; color: #ad6800; background-color: #fffbe6">kubectl get svc ingress-nginx-controller -n ingress-nginx</span>
+</li>
+</ol>
+For additional configuration options, see <a target="_blank" href="https://kubernetes.github.io/ingress-nginx/deploy/#scaleway">ingress-nginx documentation for Scaleway</a>.
+
+</details>  
+<br>
 
 #### Node requirements
 * Memory: 5000 MB


### PR DESCRIPTION
@NimRegev As requested here is the documentation provided inline. I imagine each section being expandable. I think it's important that we keep all provider-specific instructions together. Especially for Google which is more complex than the other providers. 

I do worry people will think a specific solution is tested so I added some language there aswell. 

Signed-off-by: Dan Garfield <dan@todaywasawesome.com>